### PR TITLE
Fixed CultureInfo.InvariantCulture

### DIFF
--- a/Source/OldSchoolAdventure/Source Code/Program.cs
+++ b/Source/OldSchoolAdventure/Source Code/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace OSA
 {
@@ -8,6 +9,7 @@ namespace OSA
         {
             try
             {
+                CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
                 using (PlatformerGame game = PlatformerGame.Instance)
                 {
                     game.Run();


### PR DESCRIPTION
Fixed all behavior errors when using float.Parse for the period separator when using a comma-separated CultureInfo.